### PR TITLE
MBA-47: Add tests for products, boxes and orders routers

### DIFF
--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-const Box = mongoose.model('Box');
+const Box = require('./Box');
 
 const OrderSchema = new mongoose.Schema(
   {

--- a/src/tests/routes/boxesRouter.test.js
+++ b/src/tests/routes/boxesRouter.test.js
@@ -1,0 +1,116 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+
+const boxRouter = require('../../routes/boxesRouter');
+const Box = require('../../models/Box');
+
+let app;
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri(), {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/boxes', boxRouter);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await Box.deleteMany({});
+});
+
+describe('Boxes Router', () => {
+  describe('GET /api/boxes', () => {
+    it('should return all boxes', async () => {
+      await Box.create([
+        { name: 'Small', weight: 5, price: 10 },
+        { name: 'Large', weight: 10, price: 18 }
+      ]);
+
+      const res = await request(app).get('/api/boxes');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.boxes.length).toBe(2);
+      expect(res.body.boxes.map((box) => (box.name)).sort()).toEqual(['Large', 'Small']);
+    });
+  });
+
+  describe('POST /api/boxes', () => {
+    it('should create a new box', async () => {
+      const res = await request(app)
+        .post('/api/boxes')
+        .send({ name: 'Medium', weight: 7, price: 15 });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.box).toHaveProperty('name', 'Medium');
+
+      const boxInDb = await Box.findOne({ name: 'Medium' });
+      expect(boxInDb).not.toBeNull();
+    });
+
+    it('should return 400 if missing fields', async () => {
+      const res = await request(app)
+        .post('/api/boxes')
+        .send({ name: 'Invalid' });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toMatch(/required/i);
+    });
+  });
+
+  describe('PUT /api/boxes/:id', () => {
+    it('should update a box', async () => {
+      const box = await Box.create({ name: 'Old Box', weight: 5, price: 10 });
+
+      const res = await request(app)
+        .put(`/api/boxes/${box._id}`)
+        .send({ name: 'Updated Box', weight: 6, price: 12 });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.box.name).toBe('Updated Box');
+    });
+
+    it('should return 404 if box not found', async () => {
+      const nonExistentId = new mongoose.Types.ObjectId();
+      const res = await request(app)
+        .put(`/api/boxes/${nonExistentId}`)
+        .send({ name: 'Nonexistent', weight: 5, price: 10 });
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toMatch(/not found/i);
+    });
+  });
+
+  describe('DELETE /api/boxes/:id', () => {
+    it('should delete a box', async () => {
+      const box = await Box.create({ name: 'ToDelete', weight: 4, price: 8 });
+
+      const res = await request(app).delete(`/api/boxes/${box._id}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.msg).toMatch(/deleted/i);
+
+      const boxInDb = await Box.findById(box._id);
+      expect(boxInDb).toBeNull();
+    });
+
+    it('should return 404 for nonexistent box', async () => {
+      const nonExistentId = new mongoose.Types.ObjectId();
+      const res = await request(app).delete(`/api/boxes/${nonExistentId}`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toMatch(/not found/i);
+    });
+  });
+});

--- a/src/tests/routes/ordersRouter.test.js
+++ b/src/tests/routes/ordersRouter.test.js
@@ -1,0 +1,149 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+
+const Order = require('../../models/Order');
+const Box = require('../../models/Box');
+const Product = require('../../models/Product');
+const ordersRouter = require('../../routes/ordersRouter');
+
+let app, mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri(), {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/orders', ordersRouter);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await Promise.all([
+    Order.deleteMany({}),
+    Box.deleteMany({}),
+    Product.deleteMany({})
+  ]);
+});
+
+describe('Orders Router', () => {
+  let userId, productId, boxId;
+
+  beforeEach(async () => {
+    userId = new mongoose.Types.ObjectId();
+    productId = (await Product.create({ name: 'Apple', category: 'fruits' }))._id;
+    boxId = (await Box.create({ name: 'Small Box', weight: 5, price: 35 }))._id;
+  });
+
+  describe('POST /api/orders', () => {
+    it('should create a new order and pack items into boxes', async () => {
+      const items = [{ product_id: productId, weight: 5 }];
+
+      const res = await request(app)
+        .post('/api/orders')
+        .send({
+          user_id: userId,
+          items,
+          delivery_address: '123 Farm Road',
+          delivery_first_name: 'Alice',
+          delivery_last_name: 'Green',
+          delivery_phone: '1234567890',
+          delivery_email: 'alice@example.com',
+          delivery_additional_info: ''
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.order).toHaveProperty('_id');
+      expect(res.body.order.boxes.length).toBe(1);
+      expect(res.body.order.totalOrderPrice).toBe(35);
+    });
+
+    it('should return 400 if user_id or items are missing', async () => {
+      const res = await request(app).post('/api/orders').send({});
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /api/orders', () => {
+    it('should return all orders for a user', async () => {
+      await Order.createOrderWithBoxes(
+        {
+          user_id: userId,
+          delivery_address: '456 River St',
+          delivery_first_name: 'Bob',
+          delivery_last_name: 'Smith',
+          delivery_email: 'bob@example.com'
+        },
+        [{ product_id: productId, weight: 10 }]
+      );
+
+      const res = await request(app).get(`/api/orders?user_id=${userId}`);
+      expect(res.statusCode).toBe(200);
+      expect(res.body.orders.length).toBe(1);
+    });
+  });
+
+  describe('GET /api/orders/:id', () => {
+    it('should return a specific order', async () => {
+      const order = await Order.createOrderWithBoxes(
+        {
+          user_id: userId,
+          delivery_address: '789 Hilltop',
+          delivery_first_name: 'Charlie',
+          delivery_last_name: 'Brown',
+          delivery_email: 'charlie@example.com'
+        },
+        [{ product_id: productId, weight: 200 }]
+      );
+
+      const res = await request(app).get(`/api/orders/${order._id}`);
+      expect(res.statusCode).toBe(200);
+      expect(res.body.order).toHaveProperty('_id');
+    });
+
+    it('should return 404 if order not found', async () => {
+      const fakeId = new mongoose.Types.ObjectId();
+      const res = await request(app).get(`/api/orders/${fakeId}`);
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('PUT /api/orders/:id', () => {
+    it('should update the status of an order', async () => {
+      const order = await Order.createOrderWithBoxes(
+        {
+          user_id: userId,
+          delivery_address: '22 Oak St',
+          delivery_first_name: 'Dana',
+          delivery_last_name: 'Jones',
+          delivery_email: 'dana@example.com'
+        },
+        [{ product_id: productId, weight: 10 }]
+      );
+
+      const res = await request(app)
+        .put(`/api/orders/${order._id}`)
+        .send({ status: 'shipped' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.order.status).toBe('shipped');
+    });
+
+    it('should return 404 if order does not exist', async () => {
+      const res = await request(app)
+        .put(`/api/orders/${new mongoose.Types.ObjectId()}`)
+        .send({ status: 'cancelled' });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/src/tests/routes/productsRouter.test.js
+++ b/src/tests/routes/productsRouter.test.js
@@ -1,0 +1,116 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+
+const productsRouter = require('../../routes/productsRouter');
+const Product = require('../../models/Product');
+
+let app;
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri(), {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/products', productsRouter);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await Product.deleteMany({});
+});
+
+describe('Products Router', () => {
+  describe('GET /api/products', () => {
+    it('should return all products', async () => {
+      await Product.create([
+        { name: 'Carrot', category: 'vegetables', image: '' },
+        { name: 'Apple', category: 'fruits', image: '' }
+      ]);
+
+      const res = await request(app).get('/api/products');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.products.length).toBe(2);
+      expect(res.body.products[0]).toHaveProperty('name', 'Carrot');
+    });
+  });
+
+  describe('POST /api/products', () => {
+    it('should create a new product', async () => {
+      const res = await request(app)
+        .post('/api/products')
+        .send({ name: 'Spinach', category: 'greens', image: 'image.jpg' });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.product.name).toBe('Spinach');
+
+      const productInDb = await Product.findOne({ name: 'Spinach' });
+      expect(productInDb).not.toBeNull();
+    });
+
+    it('should return 400 if required fields are missing', async () => {
+      const res = await request(app)
+        .post('/api/products')
+        .send({ name: 'NoCategory' });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toMatch(/required/i);
+    });
+  });
+
+  describe('PUT /api/products/:id', () => {
+    it('should update a product', async () => {
+      const product = await Product.create({ name: 'Tomato', category: 'vegetables' });
+
+      const res = await request(app)
+        .put(`/api/products/${product._id}`)
+        .send({ name: 'Cherry Tomato', category: 'vegetables', image: '' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.product.name).toBe('Cherry Tomato');
+    });
+
+    it('should return 404 for non-existent product', async () => {
+      const fakeId = new mongoose.Types.ObjectId();
+      const res = await request(app)
+        .put(`/api/products/${fakeId}`)
+        .send({ name: 'Ghost', category: 'greens' });
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toMatch(/not found/i);
+    });
+  });
+
+  describe('DELETE /api/products/:id', () => {
+    it('should delete a product', async () => {
+      const product = await Product.create({ name: 'Lettuce', category: 'greens' });
+
+      const res = await request(app).delete(`/api/products/${product._id}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.msg).toMatch(/deleted/i);
+
+      const deleted = await Product.findById(product._id);
+      expect(deleted).toBeNull();
+    });
+
+    it('should return 404 if product not found', async () => {
+      const fakeId = new mongoose.Types.ObjectId();
+      const res = await request(app).delete(`/api/products/${fakeId}`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toMatch(/not found/i);
+    });
+  });
+});


### PR DESCRIPTION
MBA-47: Add tests for products, boxes and orders routers

### Description

In this PR you can find tests for:
- boxesRouter.js
- productsRouter.js
- ordersRouter.js

To run the tests you would need to:
1. Install dependancies:
```npm install```

2. Run tests:
```npm test```
For the tests we use MongoMemoryServer, so this will automatically spin up an in-memory MongoDB instance for testing.